### PR TITLE
ニュース検索機能の実装

### DIFF
--- a/src/main/java/com/demo/repository/PickRepository.java
+++ b/src/main/java/com/demo/repository/PickRepository.java
@@ -1,7 +1,11 @@
 package com.demo.repository;
 
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import com.demo.domain.Pick;
 
@@ -14,4 +18,6 @@ import com.demo.domain.Pick;
 @Repository
 public interface PickRepository extends JpaRepository<Pick, Integer> {
 
+	@Query("SELECT p FROM Pick p where p.title, p.body like %:keyword% order by p.id DESC")
+	List<Pick> findByKeyword(@Param("keyword") String keyword);
 }

--- a/src/main/java/com/demo/repository/PickRepository.java
+++ b/src/main/java/com/demo/repository/PickRepository.java
@@ -18,6 +18,6 @@ import com.demo.domain.Pick;
 @Repository
 public interface PickRepository extends JpaRepository<Pick, Integer> {
 
-	@Query("SELECT DISTINCT p FROM Pick p where p.title like %:keyword% OR p.body like %:keyword% ORDER BY p.id DESC")
+	@Query("SELECT p FROM Pick p where p.title like %:keyword% OR p.body like %:keyword% ORDER BY p.id DESC")
 	List<Pick> findByKeyword(@Param("keyword") String keyword);
 }

--- a/src/main/java/com/demo/repository/PickRepository.java
+++ b/src/main/java/com/demo/repository/PickRepository.java
@@ -18,6 +18,6 @@ import com.demo.domain.Pick;
 @Repository
 public interface PickRepository extends JpaRepository<Pick, Integer> {
 
-	@Query("SELECT p FROM Pick p where p.title, p.body like %:keyword% order by p.id DESC")
+	@Query("SELECT DISTINCT p FROM Pick p where p.title like %:keyword% OR p.body like %:keyword% ORDER BY p.id DESC")
 	List<Pick> findByKeyword(@Param("keyword") String keyword);
 }

--- a/src/main/java/com/demo/service/PickService.java
+++ b/src/main/java/com/demo/service/PickService.java
@@ -32,4 +32,13 @@ public class PickService {
 	public List<Pick> findAll() {
 		return pickRepository.findAll();
 	}
+	
+	/**
+	 * ピックをキーワードから検索する業務ロジック
+	 * @param keyword ユーザがフォームに入力したキーワード
+	 * @return DBから取得した、キーワードをタイトル(title)、本文(body)に含むピックのリスト
+	 */
+	public List<Pick> findByKeyword(String keyword) {
+		return pickRepository.findByKeyword(keyword);
+	}
 }

--- a/src/main/java/com/demo/web/PickController.java
+++ b/src/main/java/com/demo/web/PickController.java
@@ -4,6 +4,8 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import com.demo.domain.Pick;
 import com.demo.service.PickService;
@@ -21,13 +23,40 @@ public class PickController {
 	PickService pickService;
 	
 	/**
+	 * 検索フォームクラスを初期化するメソッド。返り値を自動的にModel に追加する
+	 * @return 検索フォームのパラメータをバインドする PickSearchForm クラス
+	 */
+	@ModelAttribute
+	PickSearchForm setUpForm() {
+		return new PickSearchForm();
+	}
+	
+	/**
+	 * トップページを表示するメソッド。
 	 * @param model 画面に渡す値をModelオブジェクトの属性に設定
 	 * @return 遷移する画面（ニュースを表示したトップページ）の名前
 	 */
 	@GetMapping
-	String list(Model model) {
+	String index(Model model) {
 		List<Pick> picks = pickService.findAll();
 		model.addAttribute("picks", picks);
 		return "picks/index";
+	}
+	
+	/**
+	 * ユーザが入力したキーワードから検索画面を表示させるメソッド。
+	 * @param keyword ユーザが入力したキーワード
+	 * @param result キーワードをバリデーションにかけた結果が格納される
+	 * @param model 画面に渡す値をModelオブジェクトの属性に設定
+	 * @return 検索結果を表示する画面のパス
+	 */
+	@GetMapping(path = "search")
+	String search(@Validated PickSearchForm keyword, BindingResult result, Model model) {
+		if (result.hasErrors()) {
+			return index(model);
+		}
+		List<Pick> picks = pickService.findByKeyword(keyword);
+		model.addAttribute("picks", picks);
+		return "picks/search";
 	}
 }

--- a/src/main/java/com/demo/web/PickController.java
+++ b/src/main/java/com/demo/web/PickController.java
@@ -50,7 +50,7 @@ public class PickController {
 	 * @param model 画面に渡す値をModelオブジェクトの属性に設定
 	 * @return 検索結果を表示する画面のパス
 	 */
-	@GetMapping(path = "search")
+	@GetMapping("search")
 	String search(@Validated PickSearchForm form, BindingResult result, Model model) {
 		if (result.hasErrors()) {
 			return index(model);

--- a/src/main/java/com/demo/web/PickController.java
+++ b/src/main/java/com/demo/web/PickController.java
@@ -55,6 +55,7 @@ public class PickController {
 		if (result.hasErrors()) {
 			return index(model);
 		}
+		model.addAttribute("keyword", form.getKeyword());
 		List<Pick> picks = pickService.findByKeyword(form.getKeyword());
 		model.addAttribute("picks", picks);
 		return "picks/search";

--- a/src/main/java/com/demo/web/PickController.java
+++ b/src/main/java/com/demo/web/PickController.java
@@ -45,7 +45,7 @@ public class PickController {
 	
 	/**
 	 * ユーザが入力したキーワードから検索画面を表示させるメソッド。
-	 * @param keyword ユーザが入力したキーワード
+	 * @param form ユーザが入力したキーワード
 	 * @param result キーワードをバリデーションにかけた結果が格納される
 	 * @param model 画面に渡す値をModelオブジェクトの属性に設定
 	 * @return 検索結果を表示する画面のパス

--- a/src/main/java/com/demo/web/PickController.java
+++ b/src/main/java/com/demo/web/PickController.java
@@ -51,11 +51,11 @@ public class PickController {
 	 * @return 検索結果を表示する画面のパス
 	 */
 	@GetMapping(path = "search")
-	String search(@Validated PickSearchForm keyword, BindingResult result, Model model) {
+	String search(@Validated PickSearchForm form, BindingResult result, Model model) {
 		if (result.hasErrors()) {
 			return index(model);
 		}
-		List<Pick> picks = pickService.findByKeyword(keyword);
+		List<Pick> picks = pickService.findByKeyword(form.getKeyword());
 		model.addAttribute("picks", picks);
 		return "picks/search";
 	}

--- a/src/main/java/com/demo/web/PickSearchForm.java
+++ b/src/main/java/com/demo/web/PickSearchForm.java
@@ -1,0 +1,13 @@
+package com.demo.web;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
+import lombok.Data;
+
+@Data
+public class PickSearchForm {
+	@NotNull
+	@Size(min = 1, max = 20)
+	private String keyword;
+}

--- a/src/main/java/com/demo/web/PickSearchForm.java
+++ b/src/main/java/com/demo/web/PickSearchForm.java
@@ -5,6 +5,11 @@ import javax.validation.constraints.Size;
 
 import lombok.Data;
 
+/**
+ * 検索フォームのパラメータがバインドされるクラス
+ * @author yo-tanaka2
+ *
+ */
 @Data
 public class PickSearchForm {
 	@NotNull

--- a/src/main/resources/templates/layout.html
+++ b/src/main/resources/templates/layout.html
@@ -8,6 +8,8 @@
 	<link rel="stylesheet" href="http://maxcdn.bootstrapcdn.com/bootstrap/4.1.0/css/bootstrap.min.css"/>
 </head>
 <body>
+	<div class="bg-light" style="height: 100vh; overflow: scroll;">
+
 	<!-- ヘッダ -->
 	<nav class="navbar navbar-expand-lg navbar-dark bg-dark">
 		<a class="navbar-brand" href="#">NEWSPICKS</a>
@@ -32,8 +34,12 @@
 		</div>
 	</nav>
 	
-	<div th:replace="${body}">Fake Content</div>
-
+	<div class="container">
+		<div th:replace="${body}">Fake Content</div>
+	</div>
+	
+	</div>
+		
 	<script
 		src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
 	<script

--- a/src/main/resources/templates/layout.html
+++ b/src/main/resources/templates/layout.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="ja"
+	  xmlns:th="http://www.thymeleaf.org"
+	  th:fragment="layout (title, body)">
+<head>
+	<meta charset="UTF-8" />
+	<title th:replace="${title}">NewsPicks</title>
+	<link rel="stylesheet" href="http://maxcdn.bootstrapcdn.com/bootstrap/4.1.0/css/bootstrap.min.css"/>
+</head>
+<body>
+	<!-- ヘッダ -->
+	<nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+		<a class="navbar-brand" href="#">NEWSPICKS</a>
+		<button class="navbar-toggler" type="button" data-toggle="collapse"
+			data-target="#navbarSupportedContent"
+			aria-controls="navbarSupportedContent" aria-expanded="false"
+			aria-label="Toggle navigation">
+			<span class="navbar-toggler-icon"></span>
+		</button>
+
+		<div class="collapse navbar-collapse" id="navbarSupportedContent">
+			<ul class="navbar-nav mr-auto">
+				<li class="nav-item active"><a class="nav-link" href="#">UserName
+						<span class="sr-only">(current)</span>
+				</a></li>
+			</ul>
+			<form class="form-inline my-2 my-lg-0" th:action="@{/picks/search}" th:object="${pickSearchForm}" method="get">
+				<input class="form-control mr-sm-2" type="search"
+					placeholder="Search" aria-label="Search" name="keyword" th:field="*{keyword}" th:errorclass="error-input">
+				<button class="btn btn-outline-success my-2 my-sm-0" type="submit">Search</button>
+			</form>
+		</div>
+	</nav>
+	
+	<div th:replace="${body}">Fake Content</div>
+
+	<script
+		src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
+	<script
+		src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js"></script>
+	<script
+		src="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.0/js/bootstrap.min.js"></script>
+</body>
+</html>

--- a/src/main/resources/templates/layout.html
+++ b/src/main/resources/templates/layout.html
@@ -35,6 +35,7 @@
 	</nav>
 	
 	<div class="container">
+		<!--  ここに各HTMLが差し込まれる -->
 		<div th:replace="${body}">Fake Content</div>
 	</div>
 	

--- a/src/main/resources/templates/picks/index.html
+++ b/src/main/resources/templates/picks/index.html
@@ -2,12 +2,12 @@
 <html xmlns:th="http://www.thymeleaf.org"
 	  th:replace="~{layout :: layout(~{::title}, ~{::body/content()})}">
 <head>
-	<title>NewsPicks|郢晏現繝｣郢晢ｿｽ</title>
+	<title>NewsPicks|トップ</title>
 </head>
 <body>
-	<!-- 郢ｧ�ｽｳ郢晢ｽｳ郢晢ｿｽ郢晢ｽｳ郢晢ｿｽ -->
+	<!-- コンテンツ -->
 	<div class="container-fluid pt-1">
-		<!-- 郢ｧ�ｽ｢郢ｧ�ｽ､郢ｧ�ｽｭ郢晢ｽ｣郢晢ｿｽ郢晢ｿｽ -->
+		<!-- アイキャッチ -->
 		<div id="carouselExampleControls" class="carousel slide"
 			data-ride="carousel">
 			<div class="carousel-inner">
@@ -39,7 +39,7 @@
 				class="sr-only">Next</span>
 			</a>
 		</div>
-		<!-- 郢昜ｹ斟礼ｹ晢ｽｼ郢ｧ�ｽｹ郢ｧ�ｽｫ郢晢ｽｼ郢晏ｳｨ笳�邵ｺ�ｽ｡ -->
+		<!-- ニュースカードたち -->
 		<div class="pl-3">
 			<div class="row py-2">
 				<div th:each="seq : ${#numbers.sequence(4, 6)}">

--- a/src/main/resources/templates/picks/index.html
+++ b/src/main/resources/templates/picks/index.html
@@ -1,110 +1,80 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
+<html xmlns:th="http://www.thymeleaf.org"
+	  th:replace="~{layout :: layout(~{::title}, ~{::body/content()})}">
 <head>
-	<meta charset="UTF-8" />
-	<title>NewsPicks|トップ</title>
-	<link rel="stylesheet" href="http://maxcdn.bootstrapcdn.com/bootstrap/4.1.0/css/bootstrap.min.css"/>
-          
+	<title>NewsPicks|繝医ャ繝�</title>
 </head>
 <body>
-	<!-- ヘッダ -->
-	<nav class="navbar navbar-expand-lg navbar-dark bg-dark">
-		<a class="navbar-brand" href="#">NEWSPICKS</a>
-		<button class="navbar-toggler" type="button" data-toggle="collapse"
-			data-target="#navbarSupportedContent"
-			aria-controls="navbarSupportedContent" aria-expanded="false"
-			aria-label="Toggle navigation">
-			<span class="navbar-toggler-icon"></span>
-		</button>
-
-		<div class="collapse navbar-collapse" id="navbarSupportedContent">
-			<ul class="navbar-nav mr-auto">
-				<li class="nav-item active"><a class="nav-link" href="#">UserName
-						<span class="sr-only">(current)</span>
-				</a></li>
-			</ul>
-			<form class="form-inline my-2 my-lg-0" th:action="@{/picks/search}" th:object="${pickSearchForm}" method="get">
-				<input class="form-control mr-sm-2" type="search"
-					placeholder="Search" aria-label="Search" name="keyword" th:field="*{keyword}" th:errorclass="error-input">
-				<button class="btn btn-outline-success my-2 my-sm-0" type="submit">Search</button>
-			</form>
-		</div>
-	</nav>
-
-	<!-- コンテンツ -->
-	<div class="container-fluid bg-light pt-1">
-		<div class="container">
-			<!-- アイキャッチ -->
-			<div id="carouselExampleControls" class="carousel slide"
-				data-ride="carousel">
-				<div class="carousel-inner">
-					<div class="carousel-item active">
-						<img th:src="${picks[0].imageUrl}" alt="..." class="w-100"
-							style="height: 500px;">
-						<div class="carousel-caption d-none d-md-block">
-							<h5 th:text="${picks[0].title}">...</h5>
-							<p th:text="${picks[0].source}">...</p>
+		<!-- 繧ｳ繝ｳ繝�繝ｳ繝� -->
+		<div class="container-fluid bg-light pt-1">
+			<div class="container">
+				<!-- 繧｢繧､繧ｭ繝｣繝�繝� -->
+				<div id="carouselExampleControls" class="carousel slide"
+					data-ride="carousel">
+					<div class="carousel-inner">
+						<div class="carousel-item active">
+							<img th:src="${picks[0].imageUrl}" alt="..." class="w-100"
+								style="height: 500px;">
+							<div class="carousel-caption d-none d-md-block">
+								<h5 th:text="${picks[0].title}">...</h5>
+								<p th:text="${picks[0].source}">...</p>
+							</div>
+						</div>
+						<div class="carousel-item"
+							th:each="seq : ${#numbers.sequence(1, 3)}">
+							<img th:src="${picks[seq].imageUrl}" alt="..." class="w-100"
+								style="height: 500px;">
+							<div class="carousel-caption d-none d-md-block">
+								<h5 th:text="${picks[seq].title}">...</h5>
+								<p th:text="${picks[seq].source}">...</p>
+							</div>
 						</div>
 					</div>
-					<div class="carousel-item"
-						th:each="seq : ${#numbers.sequence(1, 3)}">
-						<img th:src="${picks[seq].imageUrl}" alt="..." class="w-100"
-							style="height: 500px;">
-						<div class="carousel-caption d-none d-md-block">
-							<h5 th:text="${picks[seq].title}">...</h5>
-							<p th:text="${picks[seq].source}">...</p>
+					<a class="carousel-control-prev" href="#carouselExampleControls"
+						role="button" data-slide="prev"> <span
+						class="carousel-control-prev-icon" aria-hidden="true"></span> <span
+						class="sr-only">Previous</span>
+					</a> <a class="carousel-control-next" href="#carouselExampleControls"
+						role="button" data-slide="next"> <span
+						class="carousel-control-next-icon" aria-hidden="true"></span> <span
+						class="sr-only">Next</span>
+					</a>
+				</div>
+				<!-- 繝九Η繝ｼ繧ｹ繧ｫ繝ｼ繝峨◆縺｡ -->
+				<div class="row py-2">
+					<div th:each="seq : ${#numbers.sequence(4, 6)}">
+						<div class="card mx-3" style="width: 345px; height: 500px;">
+							<img th:src="${picks[seq].imageUrl}" class="card-img-top"
+								alt="..." style="height: 200px;">
+							<div class="card-body" style="height: 300px;">
+								<h5 class="card-title" th:text="${picks[seq].title}"
+									style="height: 72px; overflow: hidden;">Card title</h5>
+								<p class="card-text" th:text="${picks[seq].body}"
+									style="height: 170px; overflow: hidden;">Some quick example
+									text to build on the card title and make up the bulk of the
+									card's content.</p>
+							</div>
 						</div>
 					</div>
 				</div>
-				<a class="carousel-control-prev" href="#carouselExampleControls"
-					role="button" data-slide="prev"> <span
-					class="carousel-control-prev-icon" aria-hidden="true"></span> <span
-					class="sr-only">Previous</span>
-				</a> <a class="carousel-control-next" href="#carouselExampleControls"
-					role="button" data-slide="next"> <span
-					class="carousel-control-next-icon" aria-hidden="true"></span> <span
-					class="sr-only">Next</span>
-				</a>
-			</div>
-			<!-- ニュースカードたち -->
-			<div class="row py-2">
-				<div th:each="seq : ${#numbers.sequence(4, 6)}">
-					<div class="card mx-3" style="width: 345px; height: 500px;">
-						<img th:src="${picks[seq].imageUrl}" class="card-img-top"
-							alt="..." style="height: 200px;">
-						<div class="card-body" style="height: 300px;">
-							<h5 class="card-title" th:text="${picks[seq].title}" style="height: 72px; overflow: hidden;">Card
-								title</h5>
-							<p class="card-text" th:text="${picks[seq].body}" style="height: 170px; overflow: hidden;">Some
-								quick example text to build on the card title and make up the
-								bulk of the card's content.</p>
-						</div>
-					</div>
-				</div>
-			</div>
-			<div class="row py-4">
-				<div th:each="seq : ${#numbers.sequence(7, 9)}">
-					<div class="card mx-3" style="width: 345px; height: 500px;">
-						<img th:src="${picks[seq].imageUrl}" class="card-img-top"
-							alt="..." style="height: 200px;">
-						<div class="card-body" style="height: 300px;">
-							<h5 class="card-title" th:text="${picks[seq].title}"  style="height: 72px; overflow: hidden;">Card
-								title</h5>
-							<p class="card-text overflow-hidden" th:text="${picks[seq].body}" style="height: 170px; overflow: hidden;">Some
-								quick example text to build on the card title and make up the
-								bulk of the card's content.</p>
+				<div class="row py-4">
+					<div th:each="seq : ${#numbers.sequence(7, 9)}">
+						<div class="card mx-3" style="width: 345px; height: 500px;">
+							<img th:src="${picks[seq].imageUrl}" class="card-img-top"
+								alt="..." style="height: 200px;">
+							<div class="card-body" style="height: 300px;">
+								<h5 class="card-title" th:text="${picks[seq].title}"
+									style="height: 72px; overflow: hidden;">Card title</h5>
+								<p class="card-text overflow-hidden"
+									th:text="${picks[seq].body}"
+									style="height: 170px; overflow: hidden;">Some quick example
+									text to build on the card title and make up the bulk of the
+									card's content.</p>
+							</div>
 						</div>
 					</div>
 				</div>
 			</div>
 		</div>
-	</div>
-
-	<script
-		src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
-	<script
-		src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js"></script>
-	<script
-		src="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.0/js/bootstrap.min.js"></script>
 </body>
 </html>

--- a/src/main/resources/templates/picks/index.html
+++ b/src/main/resources/templates/picks/index.html
@@ -23,9 +23,9 @@
 						<span class="sr-only">(current)</span>
 				</a></li>
 			</ul>
-			<form class="form-inline my-2 my-lg-0">
+			<form class="form-inline my-2 my-lg-0" th:action="@{/picks/search}" th:object="${pickSearchForm}" method="get">
 				<input class="form-control mr-sm-2" type="search"
-					placeholder="Search" aria-label="Search">
+					placeholder="Search" aria-label="Search" name="keyword" th:field="*{keyword}" th:errorclass="error-input">
 				<button class="btn btn-outline-success my-2 my-sm-0" type="submit">Search</button>
 			</form>
 		</div>

--- a/src/main/resources/templates/picks/index.html
+++ b/src/main/resources/templates/picks/index.html
@@ -2,79 +2,78 @@
 <html xmlns:th="http://www.thymeleaf.org"
 	  th:replace="~{layout :: layout(~{::title}, ~{::body/content()})}">
 <head>
-	<title>NewsPicks|繝医ャ繝�</title>
+	<title>NewsPicks|郢晏現繝｣郢晢ｿｽ</title>
 </head>
 <body>
-		<!-- 繧ｳ繝ｳ繝�繝ｳ繝� -->
-		<div class="container-fluid bg-light pt-1">
-			<div class="container">
-				<!-- 繧｢繧､繧ｭ繝｣繝�繝� -->
-				<div id="carouselExampleControls" class="carousel slide"
-					data-ride="carousel">
-					<div class="carousel-inner">
-						<div class="carousel-item active">
-							<img th:src="${picks[0].imageUrl}" alt="..." class="w-100"
-								style="height: 500px;">
-							<div class="carousel-caption d-none d-md-block">
-								<h5 th:text="${picks[0].title}">...</h5>
-								<p th:text="${picks[0].source}">...</p>
-							</div>
-						</div>
-						<div class="carousel-item"
-							th:each="seq : ${#numbers.sequence(1, 3)}">
-							<img th:src="${picks[seq].imageUrl}" alt="..." class="w-100"
-								style="height: 500px;">
-							<div class="carousel-caption d-none d-md-block">
-								<h5 th:text="${picks[seq].title}">...</h5>
-								<p th:text="${picks[seq].source}">...</p>
-							</div>
-						</div>
-					</div>
-					<a class="carousel-control-prev" href="#carouselExampleControls"
-						role="button" data-slide="prev"> <span
-						class="carousel-control-prev-icon" aria-hidden="true"></span> <span
-						class="sr-only">Previous</span>
-					</a> <a class="carousel-control-next" href="#carouselExampleControls"
-						role="button" data-slide="next"> <span
-						class="carousel-control-next-icon" aria-hidden="true"></span> <span
-						class="sr-only">Next</span>
-					</a>
-				</div>
-				<!-- 繝九Η繝ｼ繧ｹ繧ｫ繝ｼ繝峨◆縺｡ -->
-				<div class="row py-2">
-					<div th:each="seq : ${#numbers.sequence(4, 6)}">
-						<div class="card mx-3" style="width: 345px; height: 500px;">
-							<img th:src="${picks[seq].imageUrl}" class="card-img-top"
-								alt="..." style="height: 200px;">
-							<div class="card-body" style="height: 300px;">
-								<h5 class="card-title" th:text="${picks[seq].title}"
-									style="height: 72px; overflow: hidden;">Card title</h5>
-								<p class="card-text" th:text="${picks[seq].body}"
-									style="height: 170px; overflow: hidden;">Some quick example
-									text to build on the card title and make up the bulk of the
-									card's content.</p>
-							</div>
-						</div>
+	<!-- 郢ｧ�ｽｳ郢晢ｽｳ郢晢ｿｽ郢晢ｽｳ郢晢ｿｽ -->
+	<div class="container-fluid pt-1">
+		<!-- 郢ｧ�ｽ｢郢ｧ�ｽ､郢ｧ�ｽｭ郢晢ｽ｣郢晢ｿｽ郢晢ｿｽ -->
+		<div id="carouselExampleControls" class="carousel slide"
+			data-ride="carousel">
+			<div class="carousel-inner">
+				<div class="carousel-item active">
+					<img th:src="${picks[0].imageUrl}" alt="..." class="w-100"
+						style="height: 500px;">
+					<div class="carousel-caption d-none d-md-block">
+						<h5 th:text="${picks[0].title}">...</h5>
+						<p th:text="${picks[0].source}">...</p>
 					</div>
 				</div>
-				<div class="row py-4">
-					<div th:each="seq : ${#numbers.sequence(7, 9)}">
-						<div class="card mx-3" style="width: 345px; height: 500px;">
-							<img th:src="${picks[seq].imageUrl}" class="card-img-top"
-								alt="..." style="height: 200px;">
-							<div class="card-body" style="height: 300px;">
-								<h5 class="card-title" th:text="${picks[seq].title}"
-									style="height: 72px; overflow: hidden;">Card title</h5>
-								<p class="card-text overflow-hidden"
-									th:text="${picks[seq].body}"
-									style="height: 170px; overflow: hidden;">Some quick example
-									text to build on the card title and make up the bulk of the
-									card's content.</p>
-							</div>
+				<div class="carousel-item"
+					th:each="seq : ${#numbers.sequence(1, 3)}">
+					<img th:src="${picks[seq].imageUrl}" alt="..." class="w-100"
+						style="height: 500px;">
+					<div class="carousel-caption d-none d-md-block">
+						<h5 th:text="${picks[seq].title}">...</h5>
+						<p th:text="${picks[seq].source}">...</p>
+					</div>
+				</div>
+			</div>
+			<a class="carousel-control-prev" href="#carouselExampleControls"
+				role="button" data-slide="prev"> <span
+				class="carousel-control-prev-icon" aria-hidden="true"></span> <span
+				class="sr-only">Previous</span>
+			</a> <a class="carousel-control-next" href="#carouselExampleControls"
+				role="button" data-slide="next"> <span
+				class="carousel-control-next-icon" aria-hidden="true"></span> <span
+				class="sr-only">Next</span>
+			</a>
+		</div>
+		<!-- 郢昜ｹ斟礼ｹ晢ｽｼ郢ｧ�ｽｹ郢ｧ�ｽｫ郢晢ｽｼ郢晏ｳｨ笳�邵ｺ�ｽ｡ -->
+		<div class="pl-3">
+			<div class="row py-2">
+				<div th:each="seq : ${#numbers.sequence(4, 6)}">
+					<div class="card mx-2" style="width: 345px; height: 500px;">
+						<img th:src="${picks[seq].imageUrl}" class="card-img-top"
+							alt="..." style="height: 200px;">
+						<div class="card-body" style="height: 300px;">
+							<h5 class="card-title" th:text="${picks[seq].title}"
+								style="height: 72px; overflow: hidden;">Card title</h5>
+							<p class="card-text" th:text="${picks[seq].body}"
+								style="height: 170px; overflow: hidden;">Some quick example
+								text to build on the card title and make up the bulk of the
+								card's content.</p>
+						</div>
+					</div>
+				</div>
+			</div>
+			<div class="row py-4">
+				<div th:each="seq : ${#numbers.sequence(7, 9)}">
+					<div class="card mx-3" style="width: 345px; height: 500px;">
+						<img th:src="${picks[seq].imageUrl}" class="card-img-top"
+							alt="..." style="height: 200px;">
+						<div class="card-body" style="height: 300px;">
+							<h5 class="card-title" th:text="${picks[seq].title}"
+								style="height: 72px; overflow: hidden;">Card title</h5>
+							<p class="card-text overflow-hidden" th:text="${picks[seq].body}"
+								style="height: 170px; overflow: hidden;">Some quick example
+								text to build on the card title and make up the bulk of the
+								card's content.</p>
 						</div>
 					</div>
 				</div>
 			</div>
 		</div>
+	</div>
 </body>
 </html>

--- a/src/main/resources/templates/picks/search.html
+++ b/src/main/resources/templates/picks/search.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+	  th:replace="~{layout :: layout(~{::title}, ~{::body/content()})}">
+<head>
+	<title th:text="${keyword} + の検索結果"> -- の検索結果</title>
+</head>
+<body>
+	<div th:each="pick : ${picks}" class="py-4">
+		<div class="card mx-3 d-block p-2" style="height: 230px;">
+			<img th:src="${pick.imageUrl}"
+				class="card-img-top w-25 d-inline-block h-100 align-top" alt="...">
+			<div class="card-body d-inline-block h-100" style="width: 70%;">
+				<h5 class="card-title h-25" th:text="${pick.title}"
+					style="overflow: hidden;">Card title</h5>
+				<p class="card-text h-75" th:text="${pick.body}"
+					style="overflow: hidden;">Some quick example text to build on
+					the card title and make up the bulk of the card's content.</p>
+			</div>
+		</div>
+	</div>
+</body>


### PR DESCRIPTION
# 概要
- ユーザはヘッダーのフォームからキーワードを入力する
- DBから部分一致で検索結果を表示する（picks/search）

# やったこと
- （Thymeleaf Dialectで画面のヘッダー部分共通化）
- キーワードを入力するフォームの作成
- フォームから送信されたキーワードをバインドするクラスの作成（PickearchForm クラス）
- フォーム送信に対する処理のマッピング
- PickRepository へ、キーワードに部分一致するニュースを探すメソッドを追記

# 検索結果画面
<img width="1299" alt="2019-01-16 17 33 10" src="https://user-images.githubusercontent.com/40386128/51236279-1b576c80-19b5-11e9-9386-1b944d30489d.png">

